### PR TITLE
Github auth, worktree support, better completions

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -42,7 +42,7 @@ impl State {
     pub fn all_diagnostics(&self) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
-        if self.lines.len() > 1 && !self.lines[1].is_empty() {
+        if self.lines.len() > 1 && !self.lines[1].is_empty() && !self.lines[1].starts_with('#') {
             diagnostics.push(Diagnostic::new(
                 self.full_line(1),
                 "The second line should be empty!",

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,9 @@ pub struct Remote {
 
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct Repository {
+    #[serde(default)]
     pub types: Vec<CommitElementDefinition>,
+    #[serde(default)]
     pub scopes: Vec<CommitElementDefinition>,
 
     pub issue_tracker_type: Option<IssueTrackerType>,

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,33 +1,87 @@
 use git_url_parse::GitUrl;
-use std::{path::PathBuf, process::Command};
+use std::{
+    path::{Path, PathBuf}, process::Command
+};
+use tracing::info;
+
+use crate::issue_tracker::UpstreamError;
 
 /// Get the url of the `origin` remote.
-pub fn guess_repo_url() -> Option<GitUrl> {
+pub fn guess_repo_url() -> Result<GitUrl, UpstreamError> {
     let cmd = Command::new("git")
         .args(["ls-remote", "--get-url", "origin"])
-        .output()
-        .unwrap();
+        .output()?;
 
     if !cmd.status.success() {
-        return None;
+        return Err(UpstreamError::Other("Failed to get repo url".into()));
     }
 
-    let url = String::from_utf8(cmd.stdout).unwrap();
+    let url = String::from_utf8(cmd.stdout);
 
-    GitUrl::parse(url.trim()).ok()
+    Ok(GitUrl::parse(url?.trim())?)
 }
 
-pub fn get_repo_root() -> Option<PathBuf> {
+pub fn get_repo_root() -> Result<PathBuf, UpstreamError> {
     let cmd = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .unwrap();
+        .output()?;
 
-    if !cmd.status.success() {
-        return None;
+    if cmd.status.success() {
+        let path = String::from_utf8(cmd.stdout).unwrap();
+
+        return Ok(PathBuf::from(path.trim()));
     }
 
-    let path = String::from_utf8(cmd.stdout).unwrap();
+    let target_git_dir_cmd = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()?;
+    if !target_git_dir_cmd.status.success() {
+        return Err(UpstreamError::Other("Not in git repo".into()));
+    }
+    let target_git_dir_stdout = String::from_utf8(target_git_dir_cmd.stdout)?;
+    let target_git_dir = Path::new(target_git_dir_stdout.trim_end());
 
-    Some(PathBuf::from(path.trim()))
+    let base_git_dir_cmd = Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .output()?;
+    if !base_git_dir_cmd.status.success() {
+        return Err(UpstreamError::Other("Not in git repo".into()));
+    }
+    let base_git_dir_stdout = String::from_utf8(base_git_dir_cmd.stdout)?;
+    let base_git_dir = Path::new(base_git_dir_stdout.trim_end());
+    info!("base_git_dir {}", base_git_dir.display());
+
+    let worktrees_cmd = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .output()?;
+    if !worktrees_cmd.status.success() {
+        return Err(UpstreamError::Other("Failed to get worktrees".into()));
+    }
+
+    let worktrees = String::from_utf8(worktrees_cmd.stdout)?;
+    let mut base_worktree: Result<String, UpstreamError> = Err(UpstreamError::Other("Failed to find working directory".into()));
+
+    for line in worktrees.lines() {
+        if !line.starts_with("worktree ") {
+            continue;
+        }
+        let path = &line["worktree ".len()..];
+        let git_dir_cmd = Command::new("git")
+            .args(["rev-parse", "--git-dir"])
+            .current_dir(path)
+            .output()?;
+        let Ok(git_dir_stdout) = String::from_utf8(git_dir_cmd.stdout)
+        else {
+            continue;
+        };
+        let git_dir = Path::join(Path::new(path), git_dir_stdout.trim_end());
+        info!("git_dir {}", git_dir.display());
+        if git_dir == base_git_dir {
+            base_worktree = Ok(path.into());
+        } else if git_dir == target_git_dir {
+            return Ok(PathBuf::from(path));
+        }
+    }
+
+    Ok(PathBuf::from(base_worktree?))
 }

--- a/src/issue_tracker/github.rs
+++ b/src/issue_tracker/github.rs
@@ -1,12 +1,17 @@
+use std::sync::OnceLock;
+
 use async_trait::async_trait;
 use reqwest::Method;
+use secure_string::SecureString;
 use serde::Deserialize;
 use tracing::info;
 
 use super::{IssueTrackerAdapter, Ticket, UpstreamError, builder::TrackerConfig};
 
 pub struct Github {
-    user: String,
+    username: OnceLock<String>,
+    token: Option<SecureString>,
+    owner: String,
     repo: String,
     client: reqwest::Client,
 }
@@ -15,19 +20,51 @@ pub struct Github {
 struct ListIssuesResponse {
     number: u64,
     title: String,
-    body: String,
+    body: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct UserResponse {
+    login: String,
 }
 
 impl Github {
     pub fn new(config: TrackerConfig) -> Option<Self> {
-        let user = config.url.owner.clone()?;
+        let owner = config.url.owner.clone()?;
         let repo = config.url.name.clone();
-        info!("Created github instance for {user:?}@{repo}");
+        let secret = config.secret.clone();
+        info!("Created github instance for {owner:?}@{repo}");
         Some(Self {
-            user,
+            username: OnceLock::new(),
+            token: secret,
+            owner,
             repo,
             client: reqwest::Client::new(),
         })
+    }
+
+    async fn get_username(&self) -> Result<String, UpstreamError> {
+        let Some(token) = &self.token else {
+            return Ok(self.owner.clone());
+        };
+        if let Some(username) = self.username.get() {
+            return Ok(username.into());
+        }
+        let response = self
+            .client
+            .get("https://api.github.com/user")
+            .header("User-Agent", "commit-lsp")
+            .header("Accept", "application/vnd.github.raw+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("Authorization", format!("Bearer {}", token.unsecure()))
+            .send()
+            .await?;
+        let user = response.json::<UserResponse>().await?;
+        let username = user.login;
+        self.username
+            .set(username.clone())
+            .map_err(|_| UpstreamError::Other("Failed to set username".into()))?;
+        Ok(username)
     }
 }
 
@@ -35,25 +72,32 @@ impl Github {
 impl IssueTrackerAdapter for Github {
     async fn list_ticket_numbers(&self) -> Result<Vec<u64>, UpstreamError> {
         // url: https://api.github.com/repos/<user>/<repo>/issues?assignee=<user>
-        let result = self
-            .client
-            .request(
-                Method::GET,
-                format!(
-                    "https://api.github.com/repos/{0}/{1}/issues?assignee={0}",
-                    self.user, self.repo
-                ),
-            )
+        let assignee = self.get_username().await?;
+        let mut builder = self.client.request(
+            Method::GET,
+            format!(
+                "https://api.github.com/repos/{0}/{1}/issues?assignee={2}",
+                self.owner, self.repo, assignee
+            ),
+        );
+        if let Some(token) = &self.token {
+            builder = builder.header("Authorization", format!("Bearer {}", token.unsecure()));
+        }
+        let result = builder
             .header("User-Agent", "commit-lsp")
             .header("Accept", "application/vnd.github.raw+json")
             .header("X-GitHub-Api-Version", "2022-11-28")
             .send()
-            .await;
+            .await?;
 
         // TODO(texel,2025-03-27): We get all the title and body information here but the current
         // API prevents us from returning it directly. The API could be refactored, so this
         // function can return Tickets or u64 to avoid redoing some requests.
-        let response: Vec<ListIssuesResponse> = result?.json().await?;
+        if !result.status().is_success() {
+            return Err(UpstreamError::Other(result.text().await?));
+        }
+
+        let response: Vec<ListIssuesResponse> = result.json().await?;
 
         Ok(response.into_iter().map(|i| i.number).collect())
     }
@@ -61,15 +105,18 @@ impl IssueTrackerAdapter for Github {
         // url: https://api.github.com/repos/<user>/<repo>/issues/<id>
         let mut tickets = Vec::new();
         for id in ids {
-            let result = self
-                .client
-                .request(
-                    Method::GET,
-                    format!(
-                        "https://api.github.com/repos/{}/{}/issues/{}",
-                        self.user, self.repo, id
-                    ),
-                )
+            let mut builder = self.client.request(
+                Method::GET,
+                format!(
+                    "https://api.github.com/repos/{}/{}/issues/{}",
+                    self.owner, self.repo, id
+                ),
+            );
+            if let Some(token) = &self.token {
+                builder = builder.header("Authorization", format!("Bearer {}", token.unsecure()));
+            }
+
+            let result = builder
                 .header("User-Agent", "commit-lsp")
                 .header("Accept", "application/vnd.github.raw+json")
                 .header("X-GitHub-Api-Version", "2022-11-28")
@@ -81,7 +128,7 @@ impl IssueTrackerAdapter for Github {
             tickets.push(Ticket {
                 id: *id,
                 title: response.title,
-                text: response.body,
+                text: response.body.unwrap_or_default(),
             });
         }
         Ok(tickets)

--- a/src/issue_tracker/mod.rs
+++ b/src/issue_tracker/mod.rs
@@ -1,8 +1,10 @@
+use std::string::FromUtf8Error;
 use std::{collections::BTreeMap, sync::Mutex};
 
 use async_trait::async_trait;
 
 mod builder;
+use git_url_parse::GitUrlParseError;
 use ::gitlab::GitlabError;
 use ::gitlab::RestError;
 use ::gitlab::api::ApiError;
@@ -112,6 +114,24 @@ impl std::fmt::Display for UpstreamError {
             U::Authentication => write!(f, "Authentication failed"),
             U::Other(msg) => write!(f, "{msg}"),
         }
+    }
+}
+
+impl From<std::io::Error> for UpstreamError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<GitUrlParseError> for UpstreamError {
+    fn from(value: GitUrlParseError) -> Self {
+        Self::Other(value.to_string())
+    }
+}
+
+impl From<FromUtf8Error> for UpstreamError {
+    fn from(value: FromUtf8Error) -> Self {
+        Self::Other(value.to_string())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,10 +110,10 @@ fn initialize_issue_tracker(
     let check = health.start("retrieve repo url");
     let remote_url = guess_repo_url();
     match &remote_url {
-        Some(url) => check.ok_with(url.to_string()),
-        None => check.error("Failed to get remote url"),
+        Ok(url) => check.ok_with(url.to_string()),
+        Err(_) => check.error("Failed to get remote url"),
     }
-    let remote_url = remote_url?;
+    let remote_url = remote_url.ok()?;
 
     info!("Using git url '{remote_url}'");
     let mut builder = issue_tracker::Builder::new(remote_url.clone());


### PR DESCRIPTION
Fixes #4, partially addresses #5

This is a set of changes to support my common use cases:

- github auth (using the following credentials command)

	```toml
	credentials_command = ["gh", "auth", "token"]
	```

- support `git-revise`, which sets the cwd to inside the `.git` directory, including handling for worktrees
  - I also swapped `guess_repo_url` from returning an `Option` to a `Result` to help capture errors.
- allow omitting the list of scopes (as i dont have standardized scopes in many projects)
- dont report an error on the second line when it's just the comment
- support completion on '#' on the first line for issue references

---

Also notable is that i'm using this with the [helix editor](https://github.com/helix-editor/helix), with the following `languages.toml` config:

```toml
[language-server.commit-lsp]
command = "commit-lsp"
args = ["run"]

[[language]]
name = "git-commit"
file-types = [{ glob = "COMMIT_EDITMSG" }, { glob = "MERGE_MSG" }, { glob = "COMMIT_EDITMSG-*.txt" }]
language-servers = [ "commit-lsp" ]
```