### PR TITLE
Trailer completion

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -57,6 +57,22 @@ impl State {
         let cursor = pos.character as usize;
         let line = self.lines.get(pos.line as usize)?;
 
+        if line.starts_with("Co-authored-by:") || line.starts_with("Signed-off-by:") {
+            return Some(Item {
+                kind: ItemKind::Trailer,
+                text: line.clone(),
+                range: self.full_line(pos.line),
+            });
+        }
+
+        if line.is_empty() {
+            return Some(Item {
+                kind: ItemKind::EmptyLine,
+                text: String::new(),
+                range: self.full_line(pos.line),
+            });
+        }
+
         // find word under cursor
         let start = line[..cursor]
             .rfind(|c: char| !c.is_alphanumeric() && c != '#')
@@ -234,6 +250,10 @@ pub enum ItemKind {
     Scope,
     /// A reference to a ticket/issue/etc
     Ref(u64),
+    /// An empty line
+    EmptyLine,
+    /// A trailer (e.g. `Signed-off-by:` or `Co-authored-by:`)
+    Trailer,
 }
 
 #[cfg(test)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,11 +1,13 @@
 use git_url_parse::GitUrl;
+use serde::Deserialize;
 use std::{
+    io::BufRead,
     path::{Path, PathBuf},
     process::Command,
 };
 use tracing::info;
 
-use crate::issue_tracker::UpstreamError;
+use crate::{issue_tracker::UpstreamError, regex};
 
 /// Get the url of the `origin` remote.
 pub fn guess_repo_url() -> Result<GitUrl, UpstreamError> {
@@ -86,4 +88,62 @@ pub fn get_repo_root() -> Result<PathBuf, UpstreamError> {
     }
 
     Ok(PathBuf::from(base_worktree?))
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct GitAuthor {
+    pub name: String,
+    pub email: String,
+    pub commit_count: usize,
+}
+
+impl GitAuthor {
+    pub fn from_git_output(line: &str) -> Result<Self, UpstreamError> {
+        let re = regex!(r"^\s*(?P<count>\d+)\s+(?P<name>.*) <(?P<email>.*)>$");
+
+        let captures = re.captures(line).ok_or(UpstreamError::Other(
+            "Failed to parse git output".to_string(),
+        ))?;
+
+        Ok(Self {
+            name: captures
+                .name("name")
+                .expect("there should be a `name` capture")
+                .as_str()
+                .to_string(),
+            email: captures
+                .name("email")
+                .expect("there should be an `email` capture")
+                .as_str()
+                .to_string(),
+            commit_count: captures
+                .name("count")
+                .expect("there should be a `count` capture")
+                .as_str()
+                .parse()
+                .map_err(|_| {
+                    UpstreamError::Other("failed to parse git commit count".to_string())
+                })?,
+        })
+    }
+}
+
+pub fn get_repo_authors() -> Result<Box<[GitAuthor]>, UpstreamError> {
+    let authors_command = Command::new("git")
+        .args(["shortlog", "--summary", "--numbered", "--email", "--all"])
+        .output()?;
+
+    if !authors_command.status.success() {
+        return Err(UpstreamError::Other("Not in git repo".into()));
+    }
+
+    authors_command
+        .stdout
+        .lines()
+        .map(|maybe_line| {
+            maybe_line
+                .map_err(UpstreamError::Io)
+                .and_then(|line| GitAuthor::from_git_output(&line))
+        })
+        .collect()
 }

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -12,7 +12,8 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 use tracing::info;
 
-use crate::analysis::{self, ItemKind};
+use crate::analysis::{self, Item, ItemKind};
+use crate::git::GitAuthor;
 use crate::issue_tracker::IssueTracker;
 use crate::text_util::Ellipse as _;
 
@@ -20,6 +21,7 @@ struct Backend {
     client: Client,
     analysis: Mutex<analysis::State>,
     tracker: Option<Arc<IssueTracker>>,
+    authors: Option<Box<[GitAuthor]>>,
 }
 impl Backend {
     fn ticket_completion(&self, triggered: bool) -> Result<Option<CompletionResponse>> {
@@ -55,6 +57,46 @@ impl Backend {
         }
 
         Ok(Some(CompletionResponse::Array(items)))
+    }
+
+    fn trailer_kind_completion(&self) -> Result<Option<CompletionResponse>> {
+        let response = CompletionResponse::Array(vec![
+            CompletionItem::new_simple("Co-authored-by: ".to_string(), String::new()),
+            CompletionItem::new_simple("Signed-off-by: ".to_string(), String::new()),
+        ]);
+
+        Ok(Some(response))
+    }
+
+    fn coauthor_completion(&self) -> Result<Option<CompletionResponse>> {
+        let Some(authors) = self.authors.as_ref() else {
+            return Ok(None);
+        };
+
+        let response = CompletionResponse::Array(
+            authors
+                .iter()
+                .enumerate()
+                .map(|(index, author)| {
+                    let label = format!("{} <{}>", author.name, author.email);
+                    let detail = format!(
+                        "{name}\n{email}\n{commit_count} commits",
+                        name = author.name,
+                        email = author.email,
+                        commit_count = author.commit_count
+                    );
+
+                    CompletionItem {
+                        label,
+                        detail: Some(detail),
+                        sort_text: Some(format!("{index:032}")),
+                        ..CompletionItem::default()
+                    }
+                })
+                .collect(),
+        );
+
+        Ok(Some(response))
     }
 }
 
@@ -215,6 +257,12 @@ impl LanguageServer for Backend {
                     }));
                 }
             }
+            ItemKind::EmptyLine => {
+                return Ok(None);
+            }
+            ItemKind::Trailer => {
+                return Ok(None);
+            }
         }
 
         Ok(Some(Hover {
@@ -224,8 +272,9 @@ impl LanguageServer for Backend {
     }
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let analysis = self.analysis.lock().unwrap();
+
         if params.text_document_position.position.line == 0 {
-            let analysis = self.analysis.lock().unwrap();
             let trigger_character = params.context.and_then(|c| c.trigger_character);
             if trigger_character.as_ref().is_some_and(|c| c == "#") {
                 return self.ticket_completion(true);
@@ -255,11 +304,34 @@ impl LanguageServer for Backend {
 
             return Ok(Some(CompletionResponse::Array(items)));
         }
+
+        let item = analysis.lookup(params.text_document_position.position);
+
+        if let Some(Item {
+            kind: ItemKind::Trailer,
+            ..
+        }) = item
+        {
+            return self.coauthor_completion();
+        }
+
+        if let Some(Item {
+            kind: ItemKind::EmptyLine,
+            ..
+        }) = item
+        {
+            return self.trailer_kind_completion();
+        };
+
         self.ticket_completion(false)
     }
 }
 
-pub async fn run_stdio(analysis: analysis::State, remote: Option<IssueTracker>) {
+pub async fn run_stdio(
+    analysis: analysis::State,
+    remote: Option<IssueTracker>,
+    authors: Option<Box<[GitAuthor]>>,
+) {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
@@ -267,6 +339,7 @@ pub async fn run_stdio(analysis: analysis::State, remote: Option<IssueTracker>) 
         client,
         analysis: analysis.into(),
         tracker: remote.map(Arc::new),
+        authors,
     });
     Server::new(stdin, stdout, socket).serve(service).await;
 }


### PR DESCRIPTION
Adds completion for git commit trailers and git authors.

![recording](https://github.com/user-attachments/assets/70d07636-35e3-4341-b96f-03d87a1e70de)


This is currently unfinished, and now I'd like to collect some feedback on the design and learn the maintainers opinions on some points:

- What kinds of trailers should be supported?
  - Currently, `Co-authored-by` and `Signed-off-by` are hard-coded as the only two options.
  - Trailers are not standardized, and their meaning may [differ between projects][1].
    See also: [link][2], [link][3], [link][4]
  - Maybe we should make trailers configurable, like scopes and types?
- I wanted the list of authors to be sorted by "relevance", i.e. commit count.
  This was only possible to implement with a hack, since completion items can only be sorted by a string. Is this too hacky?

[1]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff:~:text=The%20meaning%20of%20a%20signoff%20depends%20on%20the%20project%20to%20which%20you%E2%80%99re%20committing
[2]: https://lore.kernel.org/git/60ad75ac7ffca_2ae08208b@natae.notmuch/
[3]: https://stackoverflow.com/questions/70430983/is-there-a-complete-reference-list-of-git-trailers-supported-by-github-documente
[4]: https://git-scm.com/docs/SubmittingPatches#commit-trailers