### PR TITLE
fix(lsp): make autocompletion more reliable

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -101,6 +101,13 @@ impl State {
         Some(Item { kind, text, range })
     }
 
+    /// Get the character at `pos` in the document
+    pub fn get_char(&self, pos: Position) -> Option<char> {
+        let line = self.lines.get(pos.line as usize)?;
+
+        line.chars().nth(pos.character as usize)
+    }
+
     pub fn commit_type_info(&self) -> Option<CommitElementDefinition> {
         let ty = self.get_text(self.ty?);
         self.config.types.iter().find(|t| t.name == ty).cloned()

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -4,7 +4,7 @@ use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionParams,
     CompletionResponse, DidChangeTextDocumentParams, DidOpenTextDocumentParams, Documentation,
     Hover, HoverContents, HoverParams, HoverProviderCapability, InitializeParams, InitializeResult,
-    InitializedParams, MarkedString, MessageType, ServerCapabilities, ServerInfo,
+    InitializedParams, MarkedString, MessageType, Position, ServerCapabilities, ServerInfo,
     TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions,
 };
 
@@ -224,13 +224,21 @@ impl LanguageServer for Backend {
     }
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let leading_char = {
+            let analysis = self.analysis.lock().unwrap();
+
+            analysis.get_char(Position::new(
+                params.text_document_position.position.line,
+                params.text_document_position.position.character - 1,
+            ))
+        };
+
         if params.text_document_position.position.line == 0 {
             let analysis = self.analysis.lock().unwrap();
-            let trigger_character = params.context.and_then(|c| c.trigger_character);
-            if trigger_character.as_ref().is_some_and(|c| c == "#") {
+            if leading_char.as_ref().is_some_and(|c| *c == '#') {
                 return self.ticket_completion(true);
             }
-            let items = if trigger_character.is_some_and(|c| c == "(") {
+            let items = if leading_char.is_some_and(|c| c == '(') {
                 analysis.get_commit_scopes()
             } else {
                 analysis.get_commit_types()


### PR DESCRIPTION
For me the autocompletion of the scopes didn't work because of my autopairs
plugin in my config, since this caused the trigger character to not be set to
"(", hence causing the scopes to never be shown to me.

This way the scopes will always be shown to the user if there is a "(" in front
of the cursor.

---

We could improve this further by making sure a commit type is in front of the
"(". I would do that in a separate PR, since my goal here was just to fix
this concrete issue. But if you prefer I could add that to this PR as well.

All of the above *should* also apply to tickets, but I did not test that.

